### PR TITLE
Add withInput fluent method for sending input to process input stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@
 target/
 test.log
 .swp
+
+.idea
+*.iml
+*.ipr
+*.iws

--- a/src/main/java/org/zeroturnaround/exec/ProcessExecutor.java
+++ b/src/main/java/org/zeroturnaround/exec/ProcessExecutor.java
@@ -20,6 +20,7 @@ package org.zeroturnaround.exec;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -304,12 +305,26 @@ public class ProcessExecutor {
 
   /**
    * Sets a stream handler for the process being executed.
+   * This will overwrite any stream redirection that was previously set to use the provided handler.
    * @return This process executor.
    */
   public ProcessExecutor streams(ExecuteStreamHandler streams) {
     validateStreams(streams, readOutput);
     this.streams = streams;
     return this;
+  }
+
+  /**
+   * Sets the input stream to redirect to the process' input stream.
+   * If this method is invoked multiples times each call overwrites the previous.
+   *
+   * @param input input stream that will be written to the process input stream (<code>null</code> means nothing will be written to the process input stream).
+   * @return This process executor.
+   */
+  public ProcessExecutor withInput(InputStream input) {
+    PumpStreamHandler pumps = pumps();
+    // Only set the input stream handler, preserve the same output and error stream handler
+    return streams(new PumpStreamHandler(pumps == null ? null : pumps.getOut(), pumps == null? null : pumps.getErr(), input));
   }
 
   /**

--- a/src/test/java/org/zeroturnaround/exec/test/InputStreamPumperTest.java
+++ b/src/test/java/org/zeroturnaround/exec/test/InputStreamPumperTest.java
@@ -45,4 +45,17 @@ public class InputStreamPumperTest {
     Assert.assertEquals(str, result);
   }
 
+  @Test
+  public void testPumpFromInputToOutputWithInput() throws Exception {
+    String str = "Tere Minu Uus vihik";
+    ByteArrayInputStream bais = new ByteArrayInputStream(str.getBytes());
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+    ProcessExecutor exec = new ProcessExecutor("java", "-cp", "target/test-classes",
+        PrintInputToOutput.class.getName()).readOutput(true).withInput(bais);
+
+    String result = exec.execute().outputUTF8();
+    Assert.assertEquals(str, result);
+  }
+
 }

--- a/src/test/java/org/zeroturnaround/exec/test/ProcessExecutorInputStreamTest.java
+++ b/src/test/java/org/zeroturnaround/exec/test/ProcessExecutorInputStreamTest.java
@@ -1,0 +1,27 @@
+package org.zeroturnaround.exec.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.zeroturnaround.exec.ProcessExecutor;
+
+/**
+ *
+ */
+public class ProcessExecutorInputStreamTest {
+  @Test
+  public void testWithInputAndRedirectOutput() throws Exception {
+    String str = "Tere Minu Uus vihik";
+    ByteArrayInputStream bais = new ByteArrayInputStream(str.getBytes());
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+    ProcessExecutor exec = new ProcessExecutor("java", "-cp", "target/test-classes",
+        PrintInputToOutput.class.getName());
+    exec.withInput(bais).redirectOutput(baos);
+
+    exec.execute();
+    Assert.assertEquals(str, baos.toString());
+  }
+}


### PR DESCRIPTION
This adds an easier way to set the input stream on the executor without the consumer having to manually create a pump handler with all three streams.
