### PR TITLE
Flush output written to process in after each write

### DIFF
--- a/src/main/java/org/zeroturnaround/exec/stream/PumpStreamHandler.java
+++ b/src/main/java/org/zeroturnaround/exec/stream/PumpStreamHandler.java
@@ -151,7 +151,7 @@ public class PumpStreamHandler implements ExecuteStreamHandler {
         inputThread = createSystemInPump(input, os);
       }
       else {
-        inputThread = createPump(input, os, true);
+        inputThread = createPump(input, os, true, true);
       }
     }
     else {
@@ -306,7 +306,7 @@ public class PumpStreamHandler implements ExecuteStreamHandler {
    * @return the stream pumper thread
    */
   protected Thread createPump(InputStream is, OutputStream os) {
-    return createPump(is, os, false);
+    return createPump(is, os, false, false);
   }
 
   /**
@@ -319,7 +319,21 @@ public class PumpStreamHandler implements ExecuteStreamHandler {
    * @return the stream pumper thread
    */
   protected Thread createPump(InputStream is, OutputStream os, boolean closeWhenExhausted) {
-    Thread result = new Thread(new StreamPumper(is, os, closeWhenExhausted));
+    return createPump(is, os, closeWhenExhausted, false);
+  }
+
+  /**
+   * Creates a stream pumper to copy the given input stream to the given
+   * output stream.
+   *
+   * @param is the input stream to copy from
+   * @param os the output stream to copy into
+   * @param closeWhenExhausted close the output stream when the input stream is exhausted
+   * @param flushImmediately flush the output stream whenever data was written to it
+   * @return the stream pumper thread
+   */
+  protected Thread createPump(InputStream is, OutputStream os, boolean closeWhenExhausted, boolean flushImmediately) {
+    Thread result = new Thread(new StreamPumper(is, os, closeWhenExhausted, flushImmediately));
     result.setDaemon(true);
     return result;
   }

--- a/src/main/java/org/zeroturnaround/exec/stream/StreamPumper.java
+++ b/src/main/java/org/zeroturnaround/exec/stream/StreamPumper.java
@@ -69,6 +69,44 @@ public class StreamPumper implements Runnable {
   /** close the output stream when exhausted */
   private final boolean closeWhenExhausted;
 
+  /** flush the output stream after each write */
+  private final boolean flushImmediately;
+
+  /**
+   * Create a new stream pumper.
+   *
+   * @param is input stream to read data from
+   * @param os output stream to write data to.
+   * @param closeWhenExhausted if true, the output stream will be closed when the input is exhausted.
+   * @param flushImmediately flush the output stream whenever data was written to it
+   */
+  public StreamPumper(final InputStream is, final OutputStream os,
+      final boolean closeWhenExhausted, boolean flushImmediately) {
+    this.is = is;
+    this.os = os;
+    this.size = DEFAULT_SIZE;
+    this.closeWhenExhausted = closeWhenExhausted;
+    this.flushImmediately = flushImmediately;
+  }
+
+  /**
+   * Create a new stream pumper.
+   *
+   * @param is input stream to read data from
+   * @param os output stream to write data to.
+   * @param closeWhenExhausted if true, the output stream will be closed when the input is exhausted.
+   * @param size the size of the internal buffer for copying the streams
+   * @param flushImmediately flush the output stream whenever data was written to it
+   */
+  public StreamPumper(final InputStream is, final OutputStream os,
+      final boolean closeWhenExhausted, final int size, boolean flushImmediately) {
+    this.is = is;
+    this.os = os;
+    this.size = (size > 0 ? size : DEFAULT_SIZE);
+    this.closeWhenExhausted = closeWhenExhausted;
+    this.flushImmediately = flushImmediately;
+  }
+
   /**
    * Create a new stream pumper.
    * 
@@ -82,6 +120,7 @@ public class StreamPumper implements Runnable {
     this.os = os;
     this.size = DEFAULT_SIZE;
     this.closeWhenExhausted = closeWhenExhausted;
+    this.flushImmediately = false;
   }
 
   /**
@@ -98,6 +137,7 @@ public class StreamPumper implements Runnable {
     this.os = os;
     this.size = (size > 0 ? size : DEFAULT_SIZE);
     this.closeWhenExhausted = closeWhenExhausted;
+    this.flushImmediately = false;
   }
 
   /**
@@ -127,6 +167,9 @@ public class StreamPumper implements Runnable {
     try {
       while ((length = is.read(buf)) > 0) {
         os.write(buf, 0, length);
+        if(flushImmediately) {
+        	os.flush();
+        }
       }
     } catch (Exception e) {
       // nothing to do - happens quite often with watchdog


### PR DESCRIPTION
On some OSes Java wraps the process output stream into a buffered one.
This may prevent data from reaching the process. This change introduces
an option to StreamPumper to flush after each write. 

Fixes zeroturnaround/zt-exec#39.

Signed-off-by: Gunnar Wagenknecht <gunnar@wagenknecht.org>