### PR TITLE
Logoutputstream linebreaks

### DIFF
--- a/src/test/java/org/zeroturnaround/exec/ProcessOutputTest.java
+++ b/src/test/java/org/zeroturnaround/exec/ProcessOutputTest.java
@@ -7,39 +7,54 @@ import org.junit.Test;
 
 public class ProcessOutputTest {
 
-  @Test(expected=NullPointerException.class)
-  public void testNull() {
-    ProcessOutput.getLinesFrom(null);
-  }
+	@Test(expected = NullPointerException.class)
+	public void testNull() {
+		ProcessOutput.getLinesFrom(null);
+	}
 
-  @Test
-  public void testSimple() {
-    Assert.assertEquals(Arrays.asList("foo"), ProcessOutput.getLinesFrom("foo"));
-  }
+	@Test
+	public void testSimple() {
+		Assert.assertEquals(Arrays.asList("foo"), ProcessOutput.getLinesFrom("foo"));
+	}
 
-  @Test
-  public void testNewLine() {
-    Assert.assertEquals(Arrays.asList("foo", "bar"), ProcessOutput.getLinesFrom("foo\nbar"));
-  }
+	@Test
+	public void testNewLine() {
+		Assert.assertEquals(Arrays.asList("foo", "bar"), ProcessOutput.getLinesFrom("foo\nbar"));
+	}
 
-  @Test
-  public void testCarriageReturn() {
-    Assert.assertEquals(Arrays.asList("foo", "bar"), ProcessOutput.getLinesFrom("foo\rbar"));
-  }
+	@Test
+	public void testNewLineWithMultipleLines() {
+		Assert.assertEquals(Arrays.asList("foo1", "bar1", "foo2", "bar2"), ProcessOutput.getLinesFrom("foo1\nbar1\nfoo2\nbar2"));
+	}
 
-  @Test
-  public void testCarriageReturnAndNewLine() {
-    Assert.assertEquals(Arrays.asList("foo", "bar"), ProcessOutput.getLinesFrom("foo\r\nbar"));
-  }
+	@Test
+	public void testCarriageReturn() {
+		Assert.assertEquals(Arrays.asList("foo", "bar"), ProcessOutput.getLinesFrom("foo\rbar"));
+	}
 
-  @Test
-  public void testTwoNewLines() {
-    Assert.assertEquals(Arrays.asList("foo", "bar"), ProcessOutput.getLinesFrom("foo\n\nbar"));
-  }
+	@Test
+	public void testCarriageReturnWithMultipleLines() {
+		Assert.assertEquals(Arrays.asList("foo1", "bar1", "foo2", "bar2"), ProcessOutput.getLinesFrom("foo1\rbar1\rfoo2\rbar2"));
+	}
 
-  @Test
-  public void testNewLineAtTheEnd() {
-    Assert.assertEquals(Arrays.asList("foo"), ProcessOutput.getLinesFrom("foo\n"));
-  }
+	@Test
+	public void testCarriageReturnAndNewLine() {
+		Assert.assertEquals(Arrays.asList("foo", "bar"), ProcessOutput.getLinesFrom("foo\r\nbar"));
+	}
+
+	@Test
+	public void testCarriageReturnAndNewLineWithMultipleLines() {
+		Assert.assertEquals(Arrays.asList("foo1", "bar1", "foo2", "bar2"), ProcessOutput.getLinesFrom("foo1\r\nbar1\r\nfoo2\r\nbar2"));
+	}
+
+	@Test
+	public void testTwoNewLines() {
+		Assert.assertEquals(Arrays.asList("foo", "bar"), ProcessOutput.getLinesFrom("foo\n\nbar"));
+	}
+
+	@Test
+	public void testNewLineAtTheEnd() {
+		Assert.assertEquals(Arrays.asList("foo"), ProcessOutput.getLinesFrom("foo\n"));
+	}
 
 }

--- a/src/test/java/org/zeroturnaround/exec/test/LogOutputStreamTest.java
+++ b/src/test/java/org/zeroturnaround/exec/test/LogOutputStreamTest.java
@@ -1,0 +1,77 @@
+package org.zeroturnaround.exec.test;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.zeroturnaround.exec.stream.LogOutputStream;
+
+public class LogOutputStreamTest {
+
+	private void testLogOutputStream(String multiLineString, String... expectedLines) throws UnsupportedEncodingException, IOException {
+		final List<String> processedLines = new ArrayList<String>();
+		LogOutputStream logOutputStream = new LogOutputStream() {
+
+			@Override
+			protected void processLine(String line) {
+				processedLines.add(line);
+			}
+		};
+		try {
+			logOutputStream.write(multiLineString.getBytes("UTF-8"));
+		} finally {
+			logOutputStream.close();
+		}
+		Assert.assertEquals(Arrays.asList(expectedLines), processedLines);
+	}
+
+	@Test
+	public void testSimple() throws UnsupportedEncodingException, IOException {
+		testLogOutputStream("foo", "foo");
+	}
+
+	@Test
+	public void testNewLine() throws UnsupportedEncodingException, IOException {
+		testLogOutputStream("foo\nbar", "foo", "bar");
+	}
+
+	@Test
+	public void testNewLineWithMultipleLines() throws UnsupportedEncodingException, IOException {
+		testLogOutputStream("foo1\nbar1\nfoo2\nbar2", "foo1", "bar1", "foo2", "bar2");
+	}
+
+	@Test
+	public void testCarriageReturn() throws UnsupportedEncodingException, IOException {
+		testLogOutputStream("foo\rbar", "foo", "bar");
+	}
+
+	@Test
+	public void testCarriageReturnWithMultipleLines() throws UnsupportedEncodingException, IOException {
+		testLogOutputStream("foo1\rbar1\rfoo2\rbar2", "foo1", "bar1", "foo2", "bar2");
+	}
+
+	@Test
+	public void testCarriageReturnAndNewLine() throws UnsupportedEncodingException, IOException {
+		testLogOutputStream("foo\r\nbar", "foo", "bar");
+	}
+
+	@Test
+	public void testCarriageReturnAndNewLineWithMultipleLines() throws UnsupportedEncodingException, IOException {
+		testLogOutputStream("foo1\r\nbar1\r\nfoo2\r\nbar2", "foo1", "bar1", "foo2", "bar2");
+	}
+
+	@Test
+	public void testTwoNewLines() throws UnsupportedEncodingException, IOException {
+		testLogOutputStream("foo\n\nbar", "foo", "bar");
+	}
+
+	@Test
+	public void testNewLineAtTheEnd() throws UnsupportedEncodingException, IOException {
+		testLogOutputStream("foo\n", "foo");
+	}
+
+}


### PR DESCRIPTION
Fix line break differences between `ProcessResult` and `LogOutputStream` of #45 