### PR TITLE
Fix BEFORE_CODE and wrong indexOf check

### DIFF
--- a/src/main/java/org/zeroturnaround/exec/ProcessInitException.java
+++ b/src/main/java/org/zeroturnaround/exec/ProcessInitException.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  */
 public class ProcessInitException extends IOException {
 
-  private static final String BEFORE_CODE = ": error=";
+  private static final String BEFORE_CODE = " error=";
   private static final String AFTER_CODE = ", ";
   private static final String NEW_INFIX = " Error=";
 

--- a/src/main/java/org/zeroturnaround/exec/ProcessInitException.java
+++ b/src/main/java/org/zeroturnaround/exec/ProcessInitException.java
@@ -67,7 +67,7 @@ public class ProcessInitException extends IOException {
       return null;
     }
     int j = m.indexOf(AFTER_CODE, i);
-    if (i == -1) {
+    if (j == -1) {
       return null;
     }
     int code;

--- a/src/test/java/org/zeroturnaround/exec/test/ProcessExecutorTimeoutTest.java
+++ b/src/test/java/org/zeroturnaround/exec/test/ProcessExecutorTimeoutTest.java
@@ -17,15 +17,16 @@
  */
 package org.zeroturnaround.exec.test;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
+import org.apache.commons.lang3.SystemUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.zeroturnaround.exec.ProcessExecutor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class ProcessExecutorTimeoutTest {
 
@@ -75,8 +76,17 @@ public class ProcessExecutorTimeoutTest {
   public void testExecuteTimeoutIssue56_1() throws Exception {
     try {
       List<String> commands = new ArrayList<String>();
-      commands.add("sleep");
-      commands.add("3");
+      if (SystemUtils.IS_OS_WINDOWS) {
+        // native sleep command is not available on Windows platform
+        // mock using standard ping to localhost instead
+        // (Windows ping does 4 requests which takes about 3 seconds)
+        commands.add("ping");
+        commands.add("127.0.0.1");
+      }
+      else {
+        commands.add("sleep");
+        commands.add("3");
+      }
       new ProcessExecutor()
           .command(commands)
           .timeout(1, TimeUnit.SECONDS)
@@ -95,8 +105,17 @@ public class ProcessExecutorTimeoutTest {
   public void testStartTimeoutIssue56_2() throws Exception {
     try {
       List<String> commands = new ArrayList<String>();
-      commands.add("sleep");
-      commands.add("3");
+      if (SystemUtils.IS_OS_WINDOWS) {
+        // native sleep command is not available on Windows platform
+        // mock using standard ping to localhost instead
+        // (Windows ping does 4 requests which takes about 3 seconds)
+        commands.add("ping");
+        commands.add("127.0.0.1");
+      }
+      else {
+        commands.add("sleep");
+        commands.add("3");
+      }
       new ProcessExecutor()
           .command(commands)
           .start()

--- a/src/test/java/org/zeroturnaround/exec/test/ProcessInitExceptionTest.java
+++ b/src/test/java/org/zeroturnaround/exec/test/ProcessInitExceptionTest.java
@@ -44,4 +44,13 @@ public class ProcessInitExceptionTest {
     Assert.assertEquals(12, e.getErrorCode());
   }
 
+  @Test
+  public void testBeforeCode() throws Exception {
+    ProcessInitException e = ProcessInitException.newInstance(
+        "Could not run test.", new IOException("java.io.IOException: Cannot run program \"sleep\": java.io.IOException: CreateProcess error=2, The system cannot find the file specified"));
+    Assert.assertNotNull(e);
+    Assert.assertEquals("Could not run test. Error=2, The system cannot find the file specified", e.getMessage());
+    Assert.assertEquals(2, e.getErrorCode());
+  }
+
 }


### PR DESCRIPTION
The string matching in ProcessInitException.newInstance() fails for an IOException message like 
'Cannot run program "foobar": CreateProcess error=2, more details...'.

The "CreateProcess" infix comes directly from the native invocation, in my case on Win10 64 bit.

Maybe the error messages have variations across OS versions/flavors, so it's hard to judge where else this might fail. One possible fix would be to soften the BEFORE_CODE to not include the colon but only "error=" (maybe a leading space would work too, as is the case with NEW_INFIX). 
I added a test in ProcessInitExceptionTest.java to cover such a case.

Another issue I discovered while fixing above problem is that after using indexOf with the AFTER_CODE and assigning it to variable "j", the next line again checks "i", which was used for the BEFORE_CODE check.

Lastly, to get the test suite to run through on Windows, I fixed the ProcessExecutorTimeoutTest test for issue #56 which are using the sleep command. There is no native sleep command on Windows, so those 2 tests always fail. I fixed that (rather creatively, I admit) by using a ping command, which on Windows always takes about 3 seconds to complete.