### PR TITLE
Eliminate some cases of log-and-throw

### DIFF
--- a/src/main/java/org/zeroturnaround/exec/ProcessExecutor.java
+++ b/src/main/java/org/zeroturnaround/exec/ProcessExecutor.java
@@ -1016,7 +1016,6 @@ public class ProcessExecutor {
       return builder.start();
     }
     catch (IOException e) {
-      log.error("Could not start process:", e);
       if (e.getClass().equals(IOException.class)) {
         String message = getExecutingErrorMessage();
         ProcessInitException p = ProcessInitException.newInstance(message, e);
@@ -1028,7 +1027,6 @@ public class ProcessExecutor {
       throw e;
     }
     catch (RuntimeException e) {
-      log.error("Could not start process:", e);
       if (e.getClass().equals(IllegalArgumentException.class)) {
         throw new IllegalArgumentException(getExecutingErrorMessage(), e);
       }

--- a/src/main/java/org/zeroturnaround/exec/close/StandardProcessCloser.java
+++ b/src/main/java/org/zeroturnaround/exec/close/StandardProcessCloser.java
@@ -68,7 +68,6 @@ public class StandardProcessCloser implements ProcessCloser {
         log.trace("Failed to close process output stream:", e);
       }
       else {
-        log.error("Failed to close process output stream:", e);
         caught = add(caught, e);
       }
     }
@@ -77,7 +76,6 @@ public class StandardProcessCloser implements ProcessCloser {
       process.getInputStream().close();
     }
     catch (IOException e) {
-      log.error("Failed to close process input stream:", e);
       caught = add(caught, e);
     }
 
@@ -85,7 +83,6 @@ public class StandardProcessCloser implements ProcessCloser {
       process.getErrorStream().close();
     }
     catch (IOException e) {
-      log.error("Failed to close process error stream:", e);
       caught = add(caught, e);
     }
 


### PR DESCRIPTION
I ran across a small number of cases of the log-and-throw antipattern in zt-exec. This is a problem because it prevents proper error handling in the layer above. For example, even if the layer above can easily recover from the error, an ERROR-level exception will still be logged by zt-exec, which will needlessly upset support folks.

So, here's a tiny little fix which simply removes the offending log statements in such cases where the exception will always be rethrown anyway.

Thanks a lot for accepting this - it's a major issue for us using zt-exec in practice. And keep up the good work on zt-exec, I really appreciate it! 👍