### PR TITLE
Added OSGi metadata support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <configuration>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
       </plugin>
@@ -123,6 +124,25 @@
             <goals>
               <goal>jar</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>5.1.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+            <configuration>
+              <bnd><![CDATA[
+Bundle-SymbolicName: org.zeroturnaround.zt-exec
+Export-Package:\
+ org.zeroturnaround.exec.*
+           ]]></bnd>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Currently the library can't be used in OSGi environments because there is no OSGi metadata available. With this pull request the maven build is modified that the resulting jar file contains all necessary OSGi metadata in the META-INF/MANIFEST.MF file.