### PR TITLE
Add an explicit module descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,36 @@ Export-Package:\
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <version>1.0.0.RC2</version>
+        <executions>
+          <execution>
+            <id>add-module-infos</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <jvmVersion>9</jvmVersion>
+              <overwriteExistingFiles>true</overwriteExistingFiles>
+              <module>
+                <moduleInfo>
+                  <name>org.zeroturnaround.exec</name>
+                  <!-- export everything -->
+                  <exports>*;</exports>
+                  <!-- declare services consumed by the artifact -->
+                  <addServiceUses>true</addServiceUses>
+                </moduleInfo>
+              </module>
+              <jdepsExtraArgs>
+                <arg>--multi-release=9</arg>
+              </jdepsExtraArgs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>


### PR DESCRIPTION
Fixes #105

The build must run with Java 11 yet the generated bytecode remains Java6 compatible.

```
$ jarviz module descriptor --file target/zt-exec-1.13-SNAPSHOT.jar 
subject: zt-exec-1.13-SNAPSHOT.jar
name: org.zeroturnaround.exec
version: 1.13-SNAPSHOT
open: false
automatic: false
exports:
  org.zeroturnaround.exec
  org.zeroturnaround.exec.close
  org.zeroturnaround.exec.listener
  org.zeroturnaround.exec.stop
  org.zeroturnaround.exec.stream
  org.zeroturnaround.exec.stream.slf4j
requires:
  java.base mandated
  slf4j.api

$ jarviz bytecode show --file target/zt-exec-1.13-SNAPSHOT.jar 
subject: zt-exec-1.13-SNAPSHOT.jar
Unversioned classes. Bytecode version: 50 total: 52
Versioned classes 9. Bytecode version: 53 total: 1
```