### PR TITLE
List all consumer-facing changes since 1.12 in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `LogOutputStream.create(LineConsumer)` to build a `LogOutputStream` from a lambda ([#107](https://github.com/zeroturnaround/zt-exec/pull/107)).
+- `LogOutputStream.setOutputCharset(String)` to control the charset used to decode the process output ([#89](https://github.com/zeroturnaround/zt-exec/pull/89)).
+- An OSGi bundle manifest (`Bundle-SymbolicName`, `Export-Package`) in the published jar ([#85](https://github.com/zeroturnaround/zt-exec/pull/85)).
+- A JPMS module descriptor for module `org.zeroturnaround.exec`, shipped as a Java 9 multi-release entry ([#106](https://github.com/zeroturnaround/zt-exec/pull/106)).
 
 ### Changed
 
-- Migrated the build from Maven to Gradle. The published jar now ships a JPMS module descriptor for `org.zeroturnaround.exec` (as a Java 9 multi-release entry) alongside the existing OSGi bundle manifest, and releases are published to Maven Central through the Sonatype Central Portal.
+- Raised the minimum Java runtime from 6 to 8 (bytecode target moved from 1.6 to 1.8).
+- Upgraded the `slf4j-api` dependency from 1.7.2 to 1.7.32.
+- Migrated the build from Maven to Gradle; releases now publish to Maven Central through the Sonatype Central Portal.
 
 ## [1.12] - 2020-09-02
 


### PR DESCRIPTION
The CHANGELOG `Unreleased` section listed only the `LogOutputStream.create(LineConsumer)` addition and the Maven→Gradle migration. Comparing against the Git history since the `zt-exec-1.12` tag, it was missing several changes a consumer upgrading from 1.12 actually sees. This fills them in so the first release (1.13.0) documents the real 1.12→1.13.0 delta.

Added to the changelog:

- **`LogOutputStream.setOutputCharset(String)`** — new public API ([#89](https://github.com/zeroturnaround/zt-exec/pull/89)).
- **OSGi bundle manifest** in the jar — new since 1.12 ([#85](https://github.com/zeroturnaround/zt-exec/pull/85)); the previous wording called it "existing", which is only true relative to the pre-conversion build, not to 1.12.
- **JPMS module descriptor** (`org.zeroturnaround.exec`) ([#106](https://github.com/zeroturnaround/zt-exec/pull/106)).
- **Minimum Java runtime raised 6 → 8** (1.12 compiled `source/target 1.6`) — the most consumer-impactful change.
- **`slf4j-api` bumped 1.7.2 → 1.7.32** (transitive, consumer-visible).

Verified the release automation still parses the updated file: `prepare-changelog-release.sh 1.13.0` promotes it cleanly to a dated `## [1.13.0]` section.
